### PR TITLE
Add collection support

### DIFF
--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_view"
+require "view_component/collection"
 require "view_component/base"
 require "view_component/render_monkey_patch"
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -30,5 +30,41 @@ module ViewComponent
     def render?
       true
     end
+
+    private
+
+    class << self
+      # Render a component for each element in a collection ([documentation](/guide/collections)):
+      #
+      #     render(ProductsComponent.with_collection(@products, foo: :bar))
+      #
+      # @param collection [Enumerable] A list of items to pass the ViewComponent one at a time.
+      # @param args [Arguments] Arguments to pass to the ViewComponent every time.
+      def with_collection(collection, **args)
+        Collection.new(self, collection, **args)
+      end
+
+      # Set the parameter name used when rendering elements of a collection ([documentation](/guide/collections)):
+      #
+      #     with_collection_parameter :item
+      #
+      # @param parameter [Symbol] The parameter name used when rendering elements of a collection.
+      def with_collection_parameter(parameter)
+        @provided_collection_parameter = parameter
+      end
+
+      # @private
+      def collection_parameter
+        if provided_collection_parameter
+          provided_collection_parameter
+        else
+          name && name.demodulize.underscore.chomp("_component").to_sym
+        end
+      end
+
+      def provided_collection_parameter
+        @provided_collection_parameter ||= nil
+      end
+    end
   end
 end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "view_component/collection"
-
 module ViewComponent
   class Base < ActionView::Base
     def render_in(view_context, &block)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "view_component/collection"
+
 module ViewComponent
   class Base < ActionView::Base
     def render_in(view_context, &block)

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  class Collection
+    attr_reader :component
+
+    def render_in(view_context, &block)
+      @collection.map do |item|
+        component.new(**component_options(item)).render_in(view_context, &block)
+      end.join.html_safe # rubocop:disable Rails/OutputSafety
+    end
+
+    private
+
+    def initialize(component, object, **options)
+      @component = component
+      @collection = collection_variable(object || [])
+      @options = options
+    end
+
+    def collection_variable(object)
+      if object.respond_to?(:to_ary)
+        object.to_ary
+      else
+        raise ArgumentError.new(
+          "The value of the first argument passed to `with_collection` isn't a valid collection. " \
+          "Make sure it responds to `to_ary`."
+        )
+      end
+    end
+
+    def component_options(item)
+      item_options = { component.collection_parameter => item }
+
+      @options.merge(item_options)
+    end
+  end
+end

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -3,8 +3,8 @@
 module ViewComponent
   module VERSION
     MAJOR = 2
-    MINOR = 37
-    PATCH = 2
+    MINOR = 39
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join(".")
   end


### PR DESCRIPTION
This is theoretically working, and you can now do things like this:

```rb
Badge.with_collection(@badges)
```

The issue is, we don't really have our components set up to work on an object, like we do for view models. Our components instead take some arbitrary arguments like `text` and `color`, and uses those. [Here](https://viewcomponent.org/guide/collections.html) is the documentation on how this would work.

There are a couple options:

1. Update components to take in an object. This would probably require adding some wrapper objects for a lot of things
2. Manually iterate

I'm going to leave this PR open, in case anyone wants to modify and merge it, but if collection support isn't going to be needed, feel free to close.