### PR TITLE
Change template render path

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -17,10 +17,10 @@ module ViewComponent
 
       if block_given?
         view_context.concat(
-          view_context.render(partial: "components/#{partial}", locals: { content: view_context.capture(&block) })
+          view_context.render(file: partial, locals: { content: view_context.capture(&block) })
         )
       else
-        view_context.render partial: "components/#{partial}"
+        view_context.render file: partial
       end
     end
 


### PR DESCRIPTION
This updates the template lookup paths to use render a template with the same name as the component class. This goes hand-in-hand with the changes in Arux-Software/TCE#11313. This makes our Rails 2 version work the same as the real version, so `TestComponent` will render a template from `app/components/test_component.html.erb`.